### PR TITLE
Add minimal JavaFX desktop client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # DepthPulse
-pulso de consulta caluclo y analisis
+
+Cliente de escritorio mínimo en JavaFX para probar un backend de análisis.
+
+## Ejecutar
+
+Requisitos: Java 21 y Maven.
+
+```bash
+mvn clean javafx:run
+```
+
+La aplicación mostrará una ventana con un campo para la URL del backend, un botón **"Ejecutar análisis"** y un área donde se visualizará la respuesta cruda (JSON o texto) de la petición HTTP asíncrona.

--- a/src/main/java/com/depthpulse/DepthPulseApplication.java
+++ b/src/main/java/com/depthpulse/DepthPulseApplication.java
@@ -1,32 +1,27 @@
 package com.depthpulse;
 
-
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.context.ConfigurableApplicationContext;
 
-@SpringBootApplication(
-        exclude = { DataSourceAutoConfiguration.class,
-                HibernateJpaAutoConfiguration.class })
+/**
+ * JavaFX entry point.
+ */
 public class DepthPulseApplication extends Application {
 
     @Override
-    public void start(Stage stage) {          // JavaFX entry-point
-        // TODO cargar tu escena FXML
+    public void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(getClass().getResource("/fxml/MainView.fxml"));
+        Parent root = loader.load();
+        Scene scene = new Scene(root);
         stage.setTitle("DepthPulse");
+        stage.setScene(scene);
         stage.show();
     }
 
     public static void main(String[] args) {
-        SpringApplication.run(DepthPulseApplication.class, args);
-        launch(args);                         // arranca JavaFX
+        launch(args);
     }
 }

--- a/src/main/java/com/depthpulse/http/AnalysisClient.java
+++ b/src/main/java/com/depthpulse/http/AnalysisClient.java
@@ -1,0 +1,39 @@
+package com.depthpulse.http;
+
+import com.depthpulse.model.AnalysisResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * HTTP client layer responsible for contacting the backend.
+ */
+public class AnalysisClient {
+
+    private final HttpClient client;
+
+    public AnalysisClient() {
+        this.client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+
+    /**
+     * Execute the analysis asynchronously against the given URL.
+     */
+    public CompletableFuture<AnalysisResponse> runAnalysis(String url) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .GET()
+                .uri(URI.create(url))
+                .timeout(Duration.ofSeconds(10))
+                .build();
+
+        return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                .thenApply(response -> new AnalysisResponse(response.body()));
+    }
+}

--- a/src/main/java/com/depthpulse/model/AnalysisResponse.java
+++ b/src/main/java/com/depthpulse/model/AnalysisResponse.java
@@ -1,0 +1,6 @@
+package com.depthpulse.model;
+
+/**
+ * Simple model that wraps the raw body returned by the backend.
+ */
+public record AnalysisResponse(String body) {}

--- a/src/main/java/com/depthpulse/ui/MainController.java
+++ b/src/main/java/com/depthpulse/ui/MainController.java
@@ -1,0 +1,60 @@
+package com.depthpulse.ui;
+
+import com.depthpulse.http.AnalysisClient;
+import com.depthpulse.model.AnalysisResponse;
+import javafx.application.Platform;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Controller for the main UI.
+ */
+public class MainController {
+
+    @FXML
+    private TextField backendUrlField;
+    @FXML
+    private Button runButton;
+    @FXML
+    private ProgressIndicator progressIndicator;
+    @FXML
+    private Label statusLabel;
+    @FXML
+    private TextArea outputArea;
+
+    private final AnalysisClient client = new AnalysisClient();
+
+    @FXML
+    private void initialize() {
+        progressIndicator.setVisible(false);
+        statusLabel.setText("Listo");
+    }
+
+    @FXML
+    private void onRun() {
+        String url = backendUrlField.getText().trim();
+        if (url.isEmpty()) {
+            statusLabel.setText("URL no válida");
+            return;
+        }
+        progressIndicator.setVisible(true);
+        statusLabel.setText("Cargando...");
+        outputArea.clear();
+
+        CompletableFuture<AnalysisResponse> future = client.runAnalysis(url);
+        future.whenComplete((resp, ex) -> {
+            Platform.runLater(() -> {
+                progressIndicator.setVisible(false);
+                if (ex != null) {
+                    statusLabel.setText("Error: " + ex.getCause().getMessage());
+                    outputArea.setText("");
+                } else {
+                    statusLabel.setText("Completado");
+                    outputArea.setText(resp.body());
+                }
+            });
+        });
+    }
+}

--- a/src/main/resources/fxml/MainView.fxml
+++ b/src/main/resources/fxml/MainView.fxml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<VBox xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml" spacing="10" padding="10" fx:controller="com.depthpulse.ui.MainController">
+    <children>
+        <HBox spacing="5">
+            <children>
+                <Label text="Backend URL:" />
+                <TextField fx:id="backendUrlField" prefWidth="400" text="http://localhost:8080/analysis" />
+                <Button text="Ejecutar análisis" onAction="#onRun" />
+            </children>
+        </HBox>
+        <HBox spacing="5" alignment="CENTER_LEFT">
+            <children>
+                <ProgressIndicator fx:id="progressIndicator" visible="false" prefWidth="25" prefHeight="25" />
+                <Label fx:id="statusLabel" text="Listo" />
+            </children>
+        </HBox>
+        <TextArea fx:id="outputArea" prefRowCount="15" wrapText="true" />
+    </children>
+</VBox>


### PR DESCRIPTION
## Summary
- Implement simple JavaFX front-end with URL field, run button, status indicator and output area
- Add asynchronous HTTP client and model layer
- Document build/run command

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9f0faf1c832dafc04a1a0a4321f0