### PR TITLE
Add asynchronous dual API analysis with placeholder model

### DIFF
--- a/src/main/java/com/depthpulse/http/AnalysisClient.java
+++ b/src/main/java/com/depthpulse/http/AnalysisClient.java
@@ -1,6 +1,8 @@
 package com.depthpulse.http;
 
 import com.depthpulse.model.AnalysisResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -9,31 +11,73 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
- * HTTP client layer responsible for contacting the backend.
+ * Handles async calls to external APIs (OptionsDepth y Gexbot) and a local
+ * analysis placeholder.
  */
 public class AnalysisClient {
 
     private final HttpClient client;
+    private final ObjectMapper mapper;
 
     public AnalysisClient() {
         this.client = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
                 .build();
+        this.mapper = new ObjectMapper();
     }
 
     /**
-     * Execute the analysis asynchronously against the given URL.
+     * Orchestrates fetching data from the two APIs and running a simulated
+     * local analysis. All operations occur asynchronously.
      */
-    public CompletableFuture<AnalysisResponse> runAnalysis(String url) {
+    public CompletableFuture<AnalysisResponse> runAnalysis(String optionsUrl, String gexbotUrl) {
+        CompletableFuture<String> optionsFuture = fetchJson(optionsUrl)
+                .thenApply(this::normalizeOptionsDepth);
+        CompletableFuture<String> gexbotFuture = fetchJson(gexbotUrl)
+                .thenApply(this::normalizeGexbot);
+
+        return optionsFuture.thenCombine(gexbotFuture, (opt, gex) -> new String[]{opt, gex})
+                .thenCompose(arr -> simulateLocalAnalysis(arr[0], arr[1]));
+    }
+
+    private CompletableFuture<JsonNode> fetchJson(String url) {
         HttpRequest request = HttpRequest.newBuilder()
                 .GET()
                 .uri(URI.create(url))
                 .timeout(Duration.ofSeconds(10))
                 .build();
-
         return client.sendAsync(request, HttpResponse.BodyHandlers.ofString())
-                .thenApply(response -> new AnalysisResponse(response.body()));
+                .thenApply(HttpResponse::body)
+                .thenApply(this::readJson);
+    }
+
+    private JsonNode readJson(String body) {
+        try {
+            return mapper.readTree(body);
+        } catch (IOException e) {
+            throw new CompletionException(e);
+        }
+    }
+
+    private String normalizeOptionsDepth(JsonNode node) {
+        JsonNode data = node.path("data");
+        return data.isMissingNode() ? node.toString() : data.toString();
+    }
+
+    private String normalizeGexbot(JsonNode node) {
+        JsonNode result = node.path("result");
+        return result.isMissingNode() ? node.toString() : result.toString();
+    }
+
+    private CompletableFuture<AnalysisResponse> simulateLocalAnalysis(String options, String gex) {
+        return CompletableFuture.supplyAsync(() -> {
+            String summary = "Análisis simulado (placeholder)\n" +
+                    "OptionsDepth: " + options + "\n" +
+                    "Gexbot: " + gex;
+            return new AnalysisResponse(summary);
+        });
     }
 }

--- a/src/main/java/com/depthpulse/ui/MainController.java
+++ b/src/main/java/com/depthpulse/ui/MainController.java
@@ -14,7 +14,9 @@ import java.util.concurrent.CompletableFuture;
 public class MainController {
 
     @FXML
-    private TextField backendUrlField;
+    private TextField optionsUrlField;
+    @FXML
+    private TextField gexbotUrlField;
     @FXML
     private Button runButton;
     @FXML
@@ -34,8 +36,9 @@ public class MainController {
 
     @FXML
     private void onRun() {
-        String url = backendUrlField.getText().trim();
-        if (url.isEmpty()) {
+        String optionsUrl = optionsUrlField.getText().trim();
+        String gexbotUrl = gexbotUrlField.getText().trim();
+        if (optionsUrl.isEmpty() || gexbotUrl.isEmpty()) {
             statusLabel.setText("URL no válida");
             return;
         }
@@ -43,7 +46,7 @@ public class MainController {
         statusLabel.setText("Cargando...");
         outputArea.clear();
 
-        CompletableFuture<AnalysisResponse> future = client.runAnalysis(url);
+        CompletableFuture<AnalysisResponse> future = client.runAnalysis(optionsUrl, gexbotUrl);
         future.whenComplete((resp, ex) -> {
             Platform.runLater(() -> {
                 progressIndicator.setVisible(false);

--- a/src/main/resources/fxml/MainView.fxml
+++ b/src/main/resources/fxml/MainView.fxml
@@ -9,11 +9,17 @@
     <children>
         <HBox spacing="5">
             <children>
-                <Label text="Backend URL:" />
-                <TextField fx:id="backendUrlField" prefWidth="400" text="http://localhost:8080/analysis" />
-                <Button text="Ejecutar análisis" onAction="#onRun" />
+                <Label text="OptionsDepth URL:" />
+                <TextField fx:id="optionsUrlField" prefWidth="400" text="http://localhost:8080/options" />
             </children>
         </HBox>
+        <HBox spacing="5">
+            <children>
+                <Label text="Gexbot URL:" />
+                <TextField fx:id="gexbotUrlField" prefWidth="400" text="http://localhost:8080/gexbot" />
+            </children>
+        </HBox>
+        <Button fx:id="runButton" text="Ejecutar análisis" onAction="#onRun" />
         <HBox spacing="5" alignment="CENTER_LEFT">
             <children>
                 <ProgressIndicator fx:id="progressIndicator" visible="false" prefWidth="25" prefHeight="25" />


### PR DESCRIPTION
## Summary
- Extend client to call OptionsDepth and Gexbot APIs concurrently using `CompletableFuture`
- Normalize API responses and run a simulated local analysis
- Update JavaFX UI to handle separate endpoints and show results asynchronously

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa378626c832da0584c72c8aceb33