### PR TITLE
Add structured logging across analysis flow

### DIFF
--- a/src/main/java/com/depthpulse/DepthPulseApplication.java
+++ b/src/main/java/com/depthpulse/DepthPulseApplication.java
@@ -5,6 +5,8 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -15,15 +17,19 @@ import org.springframework.context.ConfigurableApplicationContext;
 @SpringBootApplication
 public class DepthPulseApplication extends Application {
 
+    private static final Logger log = LoggerFactory.getLogger(DepthPulseApplication.class);
+
     private ConfigurableApplicationContext context;
 
     @Override
     public void init() {
+        log.info("Starting Spring context");
         context = new SpringApplicationBuilder(DepthPulseApplication.class).run();
     }
 
     @Override
     public void start(Stage stage) throws Exception {
+        log.info("Launching JavaFX stage");
         FXMLLoader loader = new FXMLLoader(getClass().getResource("/fxml/MainView.fxml"));
         loader.setControllerFactory(context::getBean);
         Parent root = loader.load();
@@ -35,6 +41,7 @@ public class DepthPulseApplication extends Application {
 
     @Override
     public void stop() {
+        log.info("Stopping application");
         context.close();
     }
 

--- a/src/main/java/com/depthpulse/client/GetBoxApiClient.java
+++ b/src/main/java/com/depthpulse/client/GetBoxApiClient.java
@@ -1,5 +1,7 @@
 package com.depthpulse.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -8,6 +10,8 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @Component
 public class GetBoxApiClient {
 
+    private static final Logger log = LoggerFactory.getLogger(GetBoxApiClient.class);
+
     private final WebClient client;
 
     public GetBoxApiClient(@Qualifier("getBoxWebClient") WebClient client) {
@@ -15,13 +19,17 @@ public class GetBoxApiClient {
     }
 
     public String fetchRaw(String query) {
+        log.info("Requesting GetBox API with query={}", query);
         try {
-            return client.get()
+            String body = client.get()
                     .uri(uriBuilder -> uriBuilder.queryParam("query", query).build())
                     .retrieve()
                     .bodyToMono(String.class)
                     .block();
+            log.debug("GetBox API returned {} chars for query={}", body != null ? body.length() : 0, query);
+            return body;
         } catch (WebClientResponseException e) {
+            log.error("GetBox API error status={} query={}", e.getStatusCode(), query, e);
             throw new RuntimeException("GetBox API error: " + e.getStatusCode(), e);
         }
     }

--- a/src/main/java/com/depthpulse/client/OptionDepthApiClient.java
+++ b/src/main/java/com/depthpulse/client/OptionDepthApiClient.java
@@ -1,5 +1,7 @@
 package com.depthpulse.client;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -8,6 +10,8 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @Component
 public class OptionDepthApiClient {
 
+    private static final Logger log = LoggerFactory.getLogger(OptionDepthApiClient.class);
+
     private final WebClient client;
 
     public OptionDepthApiClient(@Qualifier("optionDepthWebClient") WebClient client) {
@@ -15,13 +19,17 @@ public class OptionDepthApiClient {
     }
 
     public String fetchRaw(String optionId) {
+        log.info("Requesting OptionDepth API with id={}", optionId);
         try {
-            return client.get()
+            String body = client.get()
                     .uri(uriBuilder -> uriBuilder.queryParam("id", optionId).build())
                     .retrieve()
                     .bodyToMono(String.class)
                     .block();
+            log.debug("OptionDepth API returned {} chars for id={}", body != null ? body.length() : 0, optionId);
+            return body;
         } catch (WebClientResponseException e) {
+            log.error("OptionDepth API error status={} id={}", e.getStatusCode(), optionId, e);
             throw new RuntimeException("OptionDepth API error: " + e.getStatusCode(), e);
         }
     }

--- a/src/main/java/com/depthpulse/controller/AnalysisController.java
+++ b/src/main/java/com/depthpulse/controller/AnalysisController.java
@@ -2,6 +2,8 @@ package com.depthpulse.controller;
 
 import com.depthpulse.dto.AnalysisPayload;
 import com.depthpulse.service.AnalysisService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api")
 public class AnalysisController {
+
+    private static final Logger log = LoggerFactory.getLogger(AnalysisController.class);
 
     private final AnalysisService service;
 
@@ -20,6 +24,9 @@ public class AnalysisController {
     @GetMapping("/analysis")
     public AnalysisPayload getAnalysis(@RequestParam String consulta,
                                        @RequestParam String optionId) {
-        return service.fetchBoth(consulta, optionId);
+        log.info("Received analysis request consulta={} optionId={}", consulta, optionId);
+        AnalysisPayload payload = service.fetchBoth(consulta, optionId);
+        log.debug("Returning analysis for consulta={} optionId={}", consulta, optionId);
+        return payload;
     }
 }

--- a/src/main/java/com/depthpulse/service/AnalysisService.java
+++ b/src/main/java/com/depthpulse/service/AnalysisService.java
@@ -3,10 +3,14 @@ package com.depthpulse.service;
 import com.depthpulse.client.GetBoxApiClient;
 import com.depthpulse.client.OptionDepthApiClient;
 import com.depthpulse.dto.AnalysisPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class AnalysisService {
+
+    private static final Logger log = LoggerFactory.getLogger(AnalysisService.class);
 
     private final GetBoxApiClient getBoxApiClient;
     private final OptionDepthApiClient optionDepthApiClient;
@@ -17,8 +21,12 @@ public class AnalysisService {
     }
 
     public AnalysisPayload fetchBoth(String consulta, String optionId) {
+        log.info("Fetching data for consulta={} optionId={}", consulta, optionId);
         String getbox = getBoxApiClient.fetchRaw(consulta);
+        log.debug("GetBox response size={} for consulta={} ", getbox != null ? getbox.length() : 0, consulta);
         String optionDepth = optionDepthApiClient.fetchRaw(optionId);
+        log.debug("OptionDepth response size={} for optionId={}", optionDepth != null ? optionDepth.length() : 0, optionId);
+        log.info("Combining results for consulta={} optionId={}", consulta, optionId);
         return new AnalysisPayload(consulta, getbox, optionDepth);
     }
 }

--- a/src/main/java/com/depthpulse/ui/MainController.java
+++ b/src/main/java/com/depthpulse/ui/MainController.java
@@ -6,6 +6,8 @@ import java.util.concurrent.CompletableFuture;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class MainController {
+
+    private static final Logger log = LoggerFactory.getLogger(MainController.class);
 
     @FXML
     private TextField consultaField;
@@ -43,6 +47,7 @@ public class MainController {
     private void onRun() {
         String consulta = consultaField.getText().trim();
         String optionId = optionIdField.getText().trim();
+        log.info("Run triggered with consulta={} optionId={}", consulta, optionId);
         if (consulta.isEmpty() || optionId.isEmpty()) {
             statusLabel.setText("Datos no válidos");
             return;
@@ -56,8 +61,10 @@ public class MainController {
                 .whenComplete((payload, ex) -> Platform.runLater(() -> {
                     progressIndicator.setVisible(false);
                     if (ex != null) {
+                        log.error("Analysis failed", ex);
                         statusLabel.setText("Error: " + ex.getCause().getMessage());
                     } else {
+                        log.debug("Analysis completed for consulta={} optionId={}", consulta, optionId);
                         statusLabel.setText("Completado");
                         outputArea.setText("GetBox: " + payload.getboxJson() + "\nOptionDepth: " + payload.optionDepthJson());
                     }


### PR DESCRIPTION
## Summary
- add informative logging to REST controller, service, API clients, and UI controller for tracing requests and results
- log application lifecycle events during startup and shutdown

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb395305c832d833f5e6c48605e29