### PR TITLE
Implement parallel API analysis service with simulated responses

### DIFF
--- a/src/main/java/com/depthpulse/client/GexbotClient.java
+++ b/src/main/java/com/depthpulse/client/GexbotClient.java
@@ -59,5 +59,15 @@ public class GexbotClient {
         String json = restTemplate.exchange(builder.toUriString(), HttpMethod.GET, req, String.class).getBody();
         return mapper.readTree(json);
     }
+
+    /**
+     * Temporary helper that simulates a simple response from the GetBox API.
+     * Provides deterministic data for development without contacting the
+     * remote service.
+     */
+    public String fetchRaw(String consulta) {
+        // A real implementation would issue an HTTP request using 'consulta'.
+        return String.format("{\"consulta\":\"%s\",\"score\":42}", consulta);
+    }
 }
 

--- a/src/main/java/com/depthpulse/client/OptionsDepthClient.java
+++ b/src/main/java/com/depthpulse/client/OptionsDepthClient.java
@@ -11,7 +11,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Map;
 
 @Service
 public class OptionsDepthClient {
@@ -58,6 +57,17 @@ public class OptionsDepthClient {
         // El endpoint devuelve un array de objetos
         return mapper.readValue(responseBody,
                 mapper.getTypeFactory().constructCollectionType(List.class, HeatmapPoint.class));
+    }
+
+    /**
+     * Simulated call to the OptionDepth API returning a minimal JSON payload.
+     * This allows the rest of the application to work without performing
+     * a real HTTP request while the client is still under development.
+     */
+    public String fetchRaw(String optionId) {
+        // In a real implementation this method would perform an HTTP call
+        // using the parameters in optionId and parse the JSON response.
+        return String.format("{\"optionId\":\"%s\",\"impliedVol\":0.18}", optionId);
     }
 
     public static class HeatmapPoint {

--- a/src/main/java/com/depthpulse/controller/AnalysisController.java
+++ b/src/main/java/com/depthpulse/controller/AnalysisController.java
@@ -25,7 +25,7 @@ public class AnalysisController {
     public AnalysisPayload getAnalysis(@RequestParam String consulta,
                                        @RequestParam String optionId) {
         log.info("Received analysis request consulta={} optionId={}", consulta, optionId);
-        AnalysisPayload payload = service.fetchBoth(consulta, optionId);
+        AnalysisPayload payload = service.analyze(consulta, optionId);
         log.debug("Returning analysis for consulta={} optionId={}", consulta, optionId);
         return payload;
     }

--- a/src/main/java/com/depthpulse/dto/AnalysisPayload.java
+++ b/src/main/java/com/depthpulse/dto/AnalysisPayload.java
@@ -1,3 +1,10 @@
 package com.depthpulse.dto;
 
-public record AnalysisPayload(String consulta, String getboxJson, String optionDepthJson) {}
+/**
+ * Simple container for the raw responses of both APIs and the synthesized
+ * analysis result.
+ */
+public record AnalysisPayload(String consulta,
+                              String getboxJson,
+                              String optionDepthJson,
+                              String analysisResult) { }

--- a/src/main/java/com/depthpulse/service/AnalysisService.java
+++ b/src/main/java/com/depthpulse/service/AnalysisService.java
@@ -3,10 +3,17 @@ package com.depthpulse.service;
 import com.depthpulse.client.GexbotClient;
 import com.depthpulse.client.OptionsDepthClient;
 import com.depthpulse.dto.AnalysisPayload;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service responsible for orchestrating the calls to both external APIs
+ * and producing a simple combined analysis.
+ */
 @Service
 public class AnalysisService {
 
@@ -14,19 +21,59 @@ public class AnalysisService {
 
     private final GexbotClient gexbotClient;
     private final OptionsDepthClient optionsDepthClient;
+    private final ObjectMapper mapper = new ObjectMapper();
 
     public AnalysisService(GexbotClient gexbotClient, OptionsDepthClient optionsDepthClient) {
         this.gexbotClient = gexbotClient;
         this.optionsDepthClient = optionsDepthClient;
     }
 
-    public AnalysisPayload fetchBoth(String consulta, String optionId) {
+    /**
+     * Launches both API calls in parallel and returns the raw responses
+     * together with a minimal combined analysis.
+     */
+    public AnalysisPayload analyze(String consulta, String optionId) {
         log.info("Fetching data for consulta={} optionId={}", consulta, optionId);
-        String getbox = gexbotClient.fetchRaw(consulta);
-        log.debug("GetBox response size={} for consulta={} ", getbox != null ? getbox.length() : 0, consulta);
-        String optionDepth = optionsDepthClient.fetchRaw(optionId);
-        log.debug("OptionDepth response size={} for optionId={}", optionDepth != null ? optionDepth.length() : 0, optionId);
+
+        // Run both clients asynchronously.
+        CompletableFuture<String> getboxFuture =
+                CompletableFuture.supplyAsync(() -> gexbotClient.fetchRaw(consulta));
+        CompletableFuture<String> optionFuture =
+                CompletableFuture.supplyAsync(() -> optionsDepthClient.fetchRaw(optionId));
+
+        // Join results.
+        String getbox = getboxFuture.join();
+        log.debug("GetBox response size={} for consulta={}",
+                getbox != null ? getbox.length() : 0, consulta);
+
+        String optionDepth = optionFuture.join();
+        log.debug("OptionDepth response size={} for optionId={}",
+                optionDepth != null ? optionDepth.length() : 0, optionId);
+
+        String analysis = combineResults(getbox, optionDepth);
         log.info("Combining results for consulta={} optionId={}", consulta, optionId);
-        return new AnalysisPayload(consulta, getbox, optionDepth);
+        return new AnalysisPayload(consulta, getbox, optionDepth, analysis);
+    }
+
+    private String combineResults(String getboxJson, String optionDepthJson) {
+        /*
+         * En un escenario real, aquí se invocaría un modelo de IA que:
+         * - Analizaría profundamente los datos de ambas APIs, identificando patrones relevantes.
+         * - Promediaría valores comparables y descartaría outliers que distorsionen las métricas.
+         * - Evaluaría correlaciones y otras estadísticas para producir una señal de trading.
+         * - Generaría una recomendación basada en las conclusiones anteriores.
+         *
+         * Para este ejemplo, simplemente extraemos un número de cada JSON y
+         * calculamos su promedio para demostrar el flujo de trabajo.
+         */
+        try {
+            double score = mapper.readTree(getboxJson).path("score").asDouble();
+            double impliedVol = mapper.readTree(optionDepthJson).path("impliedVol").asDouble();
+            double average = (score + impliedVol) / 2.0;
+            return "Promedio simple: " + average;
+        } catch (Exception e) {
+            log.warn("Failed to combine results", e);
+            return "Análisis no disponible";
+        }
     }
 }

--- a/src/main/java/com/depthpulse/ui/MainController.java
+++ b/src/main/java/com/depthpulse/ui/MainController.java
@@ -29,7 +29,11 @@ public class MainController {
     @FXML
     private Label statusLabel;
     @FXML
-    private TextArea outputArea;
+    private TextArea getboxArea;
+    @FXML
+    private TextArea optionDepthArea;
+    @FXML
+    private TextArea analysisArea;
 
     private final AnalysisService analysisService;
 
@@ -41,6 +45,9 @@ public class MainController {
     private void initialize() {
         progressIndicator.setVisible(false);
         statusLabel.setText("Listo");
+        getboxArea.clear();
+        optionDepthArea.clear();
+        analysisArea.clear();
     }
 
     @FXML
@@ -54,10 +61,12 @@ public class MainController {
         }
         progressIndicator.setVisible(true);
         statusLabel.setText("Cargando...");
-        outputArea.clear();
+        getboxArea.clear();
+        optionDepthArea.clear();
+        analysisArea.clear();
 
         CompletableFuture
-                .supplyAsync(() -> analysisService.fetchBoth(consulta, optionId))
+                .supplyAsync(() -> analysisService.analyze(consulta, optionId))
                 .whenComplete((payload, ex) -> Platform.runLater(() -> {
                     progressIndicator.setVisible(false);
                     if (ex != null) {
@@ -66,7 +75,9 @@ public class MainController {
                     } else {
                         log.debug("Analysis completed for consulta={} optionId={}", consulta, optionId);
                         statusLabel.setText("Completado");
-                        outputArea.setText("GetBox: " + payload.getboxJson() + "\nOptionDepth: " + payload.optionDepthJson());
+                        getboxArea.setText(payload.getboxJson());
+                        optionDepthArea.setText(payload.optionDepthJson());
+                        analysisArea.setText(payload.analysisResult());
                     }
                 }));
     }

--- a/src/main/resources/fxml/MainView.fxml
+++ b/src/main/resources/fxml/MainView.fxml
@@ -26,6 +26,11 @@
                 <Label fx:id="statusLabel" text="Listo" />
             </children>
         </HBox>
-        <TextArea fx:id="outputArea" prefRowCount="15" wrapText="true" />
+        <Label text="GetBox Result:" />
+        <TextArea fx:id="getboxArea" prefRowCount="5" wrapText="true" />
+        <Label text="OptionDepth Result:" />
+        <TextArea fx:id="optionDepthArea" prefRowCount="5" wrapText="true" />
+        <Label text="Análisis:" />
+        <TextArea fx:id="analysisArea" prefRowCount="5" wrapText="true" />
     </children>
 </VBox>


### PR DESCRIPTION
## Summary
- simulate `fetchRaw` methods for GetBox and OptionDepth API clients
- add `AnalysisService` to query both APIs in parallel and combine results with explanatory comments
- extend payload and JavaFX UI to display both raw responses and computed analysis

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c6781b1ccc832d97255b5df7996216