### PR TITLE
Add parallel API analysis and UI display

### DIFF
--- a/src/main/java/com/depthpulse/client/GetBoxClient.java
+++ b/src/main/java/com/depthpulse/client/GetBoxClient.java
@@ -92,4 +92,23 @@ public class GetBoxClient {
             throw new IllegalStateException("No se pudo parsear la respuesta de " + path, e);
         }
     }
+
+    /**
+     * Simulated call used during early development.
+     * <p>
+     * The real client above performs HTTP requests against the GetBox API. For
+     * now we want to exercise the integration flow without hitting the network,
+     * so this method returns a deterministic numeric signal based on the
+     * provided ticker. The value is intentionally simple but allows the service
+     * layer to behave as if data had been fetched from the remote endpoint.
+     * </p>
+     *
+     * @param ticker Stock symbol to "query".
+     * @return pseudo value representing some market metric.
+     */
+    public double fetchDummySignal(String ticker) {
+        LOG.debug("Simulating GetBox signal for {}", ticker);
+        // Any deterministic transformation is fine; we just need a value.
+        return Math.abs(ticker.hashCode() % 100) / 10.0;
+    }
 }

--- a/src/main/java/com/depthpulse/client/OptionsDepthClient.java
+++ b/src/main/java/com/depthpulse/client/OptionsDepthClient.java
@@ -60,6 +60,20 @@ public class OptionsDepthClient {
                 mapper.getTypeFactory().constructCollectionType(List.class, HeatmapPoint.class));
     }
 
+    /**
+     * Temporary helper that produces synthetic data so the rest of the
+     * application can be exercised without contacting the real service. The
+     * value is derived from the {@code optionId} to keep it deterministic
+     * between executions.
+     *
+     * @param optionId identifier of the option contract
+     * @return simulated metric from the options-depth API
+     */
+    public double fetchDummySignal(String optionId) {
+        // Use the hash code to obtain a pseudo value in the 0-10 range.
+        return Math.abs(optionId.hashCode() % 100) / 10.0;
+    }
+
     public static class HeatmapPoint {
         private double price;
         private double value;

--- a/src/main/java/com/depthpulse/controller/AnalysisController.java
+++ b/src/main/java/com/depthpulse/controller/AnalysisController.java
@@ -1,6 +1,6 @@
 package com.depthpulse.controller;
 
-import com.depthpulse.dto.AnalysisPayload;
+import com.depthpulse.dto.AnalysisResult;
 import com.depthpulse.service.AnalysisService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,10 +22,10 @@ public class AnalysisController {
     }
 
     @GetMapping("/analysis")
-    public AnalysisPayload getAnalysis(@RequestParam String consulta,
-                                       @RequestParam String optionId) {
+    public AnalysisResult getAnalysis(@RequestParam String consulta,
+                                      @RequestParam String optionId) {
         log.info("Received analysis request consulta={} optionId={}", consulta, optionId);
-        AnalysisPayload payload = service.fetchBoth(consulta, optionId);
+        AnalysisResult payload = service.runAnalysis(consulta, optionId);
         log.debug("Returning analysis for consulta={} optionId={}", consulta, optionId);
         return payload;
     }

--- a/src/main/java/com/depthpulse/dto/AnalysisPayload.java
+++ b/src/main/java/com/depthpulse/dto/AnalysisPayload.java
@@ -1,3 +1,0 @@
-package com.depthpulse.dto;
-
-public record AnalysisPayload(String consulta, String getboxJson, String optionDepthJson) {}

--- a/src/main/java/com/depthpulse/dto/AnalysisResult.java
+++ b/src/main/java/com/depthpulse/dto/AnalysisResult.java
@@ -1,0 +1,11 @@
+package com.depthpulse.dto;
+
+/**
+ * Simple DTO returned by the analysis service. It exposes the individual
+ * signals coming from each remote API and a textual explanation of the
+ * aggregated outcome.
+ */
+public record AnalysisResult(double getBoxSignal,
+                             double optionDepthSignal,
+                             String conclusion) {
+}

--- a/src/main/java/com/depthpulse/service/AnalysisService.java
+++ b/src/main/java/com/depthpulse/service/AnalysisService.java
@@ -2,11 +2,16 @@ package com.depthpulse.service;
 
 import com.depthpulse.client.GetBoxClient;
 import com.depthpulse.client.OptionsDepthClient;
-import com.depthpulse.dto.AnalysisPayload;
+import com.depthpulse.dto.AnalysisResult;
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+/**
+ * Service that orchestrates calls to the two API clients and performs a
+ * combined analysis of their outputs.
+ */
 @Service
 public class AnalysisService {
 
@@ -20,13 +25,48 @@ public class AnalysisService {
         this.optionsDepthClient = optionsDepthClient;
     }
 
-    public AnalysisPayload fetchBoth(String consulta, String optionId) {
-        log.info("Fetching data for consulta={} optionId={}", consulta, optionId);
-        String getbox = getBoxClient.fetchRaw(consulta);
-        log.debug("GetBox response size={} for consulta={} ", getbox != null ? getbox.length() : 0, consulta);
-        String optionDepth = optionsDepthClient.fetchRaw(optionId);
-        log.debug("OptionDepth response size={} for optionId={}", optionDepth != null ? optionDepth.length() : 0, optionId);
-        log.info("Combining results for consulta={} optionId={}", consulta, optionId);
-        return new AnalysisPayload(consulta, getbox, optionDepth);
+    /**
+     * Launches both API calls in parallel and combines their results.
+     *
+     * @param ticker   symbol used for the GetBox query
+     * @param optionId identifier for the options-depth query
+     * @return aggregated analysis result
+     */
+    public AnalysisResult runAnalysis(String ticker, String optionId) {
+        log.info("Starting analysis for ticker={} optionId={}", ticker, optionId);
+
+        // Launch both requests asynchronously. The underlying client methods are
+        // simple mock implementations at the moment, but the same structure will
+        // allow real HTTP calls without blocking this thread.
+        CompletableFuture<Double> getBoxFuture =
+                CompletableFuture.supplyAsync(() -> getBoxClient.fetchDummySignal(ticker));
+        CompletableFuture<Double> optionFuture =
+                CompletableFuture.supplyAsync(() -> optionsDepthClient.fetchDummySignal(optionId));
+
+        // Wait for both operations to complete.
+        double getBoxValue = getBoxFuture.join();
+        double optionValue = optionFuture.join();
+
+        /*
+         * Here is where a real AI model would ingest the two metrics and produce
+         * a sophisticated insight. A realistic pipeline could:
+         *   - Normalise the values according to historical volatility.
+         *   - Detect anomalies or outliers using statistical tests.
+         *   - Feed the cleaned signals into a predictive model (e.g. an LSTM
+         *     network or gradient boosting machine) to forecast short term
+         *     movements.
+         *   - Quantify the confidence of the prediction and cross-check it with
+         *     recent market regime classifiers.
+         * For demonstration purposes we implement only a tiny fraction of this
+         * reasoning by averaging the two inputs.
+         */
+        double average = (getBoxValue + optionValue) / 2.0;
+        String conclusion = average > 5
+                ? "Bullish bias detected"
+                : "Bearish or neutral bias";
+
+        log.info("Analysis complete for ticker={} optionId={}", ticker, optionId);
+        return new AnalysisResult(getBoxValue, optionValue,
+                String.format("avg=%.2f -> %s", average, conclusion));
     }
 }

--- a/src/main/java/com/depthpulse/ui/MainController.java
+++ b/src/main/java/com/depthpulse/ui/MainController.java
@@ -1,6 +1,6 @@
 package com.depthpulse.ui;
 
-import com.depthpulse.dto.AnalysisPayload;
+import com.depthpulse.dto.AnalysisResult;
 import com.depthpulse.service.AnalysisService;
 import java.util.concurrent.CompletableFuture;
 import javafx.application.Platform;
@@ -29,7 +29,11 @@ public class MainController {
     @FXML
     private Label statusLabel;
     @FXML
-    private TextArea outputArea;
+    private TextArea getBoxArea;
+    @FXML
+    private TextArea optionDepthArea;
+    @FXML
+    private TextArea analysisArea;
 
     private final AnalysisService analysisService;
 
@@ -54,10 +58,12 @@ public class MainController {
         }
         progressIndicator.setVisible(true);
         statusLabel.setText("Cargando...");
-        outputArea.clear();
+        getBoxArea.clear();
+        optionDepthArea.clear();
+        analysisArea.clear();
 
         CompletableFuture
-                .supplyAsync(() -> analysisService.fetchBoth(consulta, optionId))
+                .supplyAsync(() -> analysisService.runAnalysis(consulta, optionId))
                 .whenComplete((payload, ex) -> Platform.runLater(() -> {
                     progressIndicator.setVisible(false);
                     if (ex != null) {
@@ -66,7 +72,9 @@ public class MainController {
                     } else {
                         log.debug("Analysis completed for consulta={} optionId={}", consulta, optionId);
                         statusLabel.setText("Completado");
-                        outputArea.setText("GetBox: " + payload.getboxJson() + "\nOptionDepth: " + payload.optionDepthJson());
+                        getBoxArea.setText(String.valueOf(payload.getBoxSignal()));
+                        optionDepthArea.setText(String.valueOf(payload.optionDepthSignal()));
+                        analysisArea.setText(payload.conclusion());
                     }
                 }));
     }

--- a/src/main/resources/fxml/MainView.fxml
+++ b/src/main/resources/fxml/MainView.fxml
@@ -26,6 +26,11 @@
                 <Label fx:id="statusLabel" text="Listo" />
             </children>
         </HBox>
-        <TextArea fx:id="outputArea" prefRowCount="15" wrapText="true" />
+        <Label text="GetBox señal:" />
+        <TextArea fx:id="getBoxArea" prefRowCount="4" wrapText="true" />
+        <Label text="OptionDepth señal:" />
+        <TextArea fx:id="optionDepthArea" prefRowCount="4" wrapText="true" />
+        <Label text="Análisis combinado:" />
+        <TextArea fx:id="analysisArea" prefRowCount="4" wrapText="true" />
     </children>
 </VBox>


### PR DESCRIPTION
## Summary
- Simulate GetBox and OptionsDepth API calls with deterministic dummy signals
- Introduce AnalysisService to request both APIs in parallel and produce combined insight
- Expose results via JavaFX and REST controller with clear UI fields

## Testing
- `mvn -q test` *(fails: Network is unreachable and parent POM could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68c6798c9208832dbe3fef8bee68dc25