### PR TITLE
Provide RestTemplateBuilder bean for GetBoxClient

### DIFF
--- a/src/main/java/com/depthpulse/config/WebClientConfig.java
+++ b/src/main/java/com/depthpulse/config/WebClientConfig.java
@@ -3,6 +3,7 @@ package com.depthpulse.config;
 import io.netty.channel.ChannelOption;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -39,5 +40,10 @@ public class WebClientConfig {
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();
+    }
+
+    @Bean
+    public RestTemplateBuilder restTemplateBuilder() {
+        return new RestTemplateBuilder();
     }
 }


### PR DESCRIPTION
## Summary
- expose a `RestTemplateBuilder` bean so `GetBoxClient` can initialize a `RestTemplate` and the application context loads successfully

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; repository unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c67ef0f248832d9a5892998f60c46e